### PR TITLE
Fix rowspan height calculation using ExtraColspan instead of ExtraRowspan

### DIFF
--- a/frontend/table.go
+++ b/frontend/table.go
@@ -429,7 +429,7 @@ func (row *TableRow) setHeight() ([]span, error) {
 				maxht = ht
 			}
 		} else {
-			rowspans = append(rowspans, span{start: cell.rowStart, end: cell.rowStart + cell.ExtraColspan, size: ht})
+			rowspans = append(rowspans, span{start: cell.rowStart, end: cell.rowStart + cell.ExtraRowspan, size: ht})
 		}
 	}
 	row.table.rowHeights[row.row] = maxht


### PR DESCRIPTION
## Problem

When a table cell has `rowspan` set, `TableRow.setHeight()` in
`frontend/table.go` computes which rows the cell's height should be
distributed across using `cell.ExtraColspan` instead of
`cell.ExtraRowspan`:

```go
rowspans = append(rowspans, span{start: cell.rowStart, end: cell.rowStart + cell.ExtraColspan, size: ht})
```

This only produces the correct range when a cell's colspan and rowspan
happen to be equal. For a cell that spans multiple rows but not columns
(colspan 1, rowspan > 1 — a very common case, e.g. a logo/QR cell next
to a multi-row info block), `ExtraColspan` is `0`, so the computed range
collapses to a single row. The cell's actual content height is then never
distributed across the rows it visually spans, so those rows come out too
short and the cell's content (e.g. an image) overflows past the bottom of
its own cell into whatever follows.

## Fix

Use `cell.ExtraRowspan` instead, matching what the surrounding function
is actually trying to compute (rowspans, not colspans):

```go
rowspans = append(rowspans, span{start: cell.rowStart, end: cell.rowStart + cell.ExtraRowspan, size: ht})
```

## Reproduction

A table with a `rowspan="4"` image cell in the first column, next to
several short single-line rows, e.g.:

```html
<table>
  <tr>
    <td rowspan="4"><img style="width: 40mm" src="image.png"></td>
    <td>Some text</td>
  </tr>
  <tr><td>Row 2</td></tr>
  <tr><td>Row 3</td></tr>
  <tr><td>Row 4</td></tr>
</table>
```

Before the fix, the four rows' natural heights (short, single line each)
are never stretched to fit the 40mm image, so the image renders past the
bottom of its cell into the content below. After the fix, the rows are
stretched so their combined height matches the image, and it stays inside
its cell.