### PR TITLE
Add white-space handling and the remaining text-decoration lines

### DIFF
--- a/frontend/decoration.go
+++ b/frontend/decoration.go
@@ -2,29 +2,117 @@ package frontend
 
 import (
 	"github.com/boxesandglue/boxesandglue/backend/bag"
+	"github.com/boxesandglue/boxesandglue/backend/color"
 	"github.com/boxesandglue/boxesandglue/backend/node"
 	"github.com/boxesandglue/boxesandglue/frontend/pdfdraw"
 )
 
 type styles struct {
-	isUnderline bool
-	ulpos       bag.ScaledPoint
-	linewidth   bag.ScaledPoint
+	// decoration is the line currently open, or TextDecorationLineNone.
+	decoration TextDecorationLine
+	// style is how that line is drawn.
+	style TextDecorationStyle
+	// col overrides the text colour; nil means CSS's `currentColor`.
+	col *color.Color
+	// pos is the line's offset from the baseline, negative below it.
+	pos       bag.ScaledPoint
+	linewidth bag.ScaledPoint
 }
 
-func doUnderline(head, start, stop node.Node, st *styles) node.Node {
+// DecorationOffset returns where a text-decoration line sits relative to the
+// baseline, as a fraction of the font size. The fractions match the underline
+// offset this package has always used; no font exposes its post/OS-2
+// underline or strikeout metrics here yet, so all three lines are derived the
+// same way.
+func DecorationOffset(line TextDecorationLine, fontsize bag.ScaledPoint) bag.ScaledPoint {
+	switch line {
+	case TextDecorationUnderline:
+		return -fontsize / 6
+	case TextDecorationLineThrough:
+		// Roughly a quarter of the em above the baseline, which puts the line
+		// through the middle of lowercase letters.
+		return fontsize / 4
+	case TextDecorationOverline:
+		// Just clear of the ascender.
+		return fontsize * 4 / 5
+	}
+	return 0
+}
+
+func drawDecoration(head, start, stop node.Node, st *styles) node.Node {
 	wd, _, _ := node.Dimensions(start, stop, node.Horizontal)
-	pdfUL := pdfdraw.NewStandalone().LineWidth(st.linewidth).Moveto(0, st.ulpos).Lineto(wd, st.ulpos).Stroke().String()
+	pd := pdfdraw.NewStandalone().LineWidth(st.linewidth)
+	if st.col != nil {
+		// CSS text-decoration-color; without it the line inherits the text
+		// colour from the graphics state, which is `currentColor`.
+		pd = pd.ColorStroking(*st.col)
+	}
+	lw := st.linewidth
+	switch st.style {
+	case TextDecorationStyleDouble:
+		// Two lines, the pair centred on where the single line would sit.
+		gap := lw * 2
+		pd = pd.Moveto(0, st.pos+gap).Lineto(wd, st.pos+gap).
+			Moveto(0, st.pos-gap).Lineto(wd, st.pos-gap)
+	case TextDecorationStyleDotted:
+		// SetDash takes whole PDF units, so the pattern cannot be finer than a
+		// point however thin the line is.
+		u := dashUnit(lw)
+		pd = pd.SetDash([]uint{u, 2 * u}, 0).Moveto(0, st.pos).Lineto(wd, st.pos)
+	case TextDecorationStyleDashed:
+		u := dashUnit(lw)
+		pd = pd.SetDash([]uint{3 * u, 2 * u}, 0).Moveto(0, st.pos).Lineto(wd, st.pos)
+	case TextDecorationStyleWavy:
+		pd = wave(pd, wd, st.pos, lw)
+	default:
+		pd = pd.Moveto(0, st.pos).Lineto(wd, st.pos)
+	}
 	r := node.NewRule()
 	r.Hide = true
-	r.Pre = pdfUL
+	r.Pre = pd.Stroke().String()
 	head = node.InsertBefore(head, start, r)
 	return head
 }
 
+// dashUnit scales the dash pattern with the line width, with a floor of one
+// PDF unit because SetDash takes integers.
+func dashUnit(lw bag.ScaledPoint) uint {
+	u := uint(lw.ToPT() * 2)
+	if u < 1 {
+		u = 1
+	}
+	return u
+}
+
+// wave draws the wavy decoration as a run of half-period Bézier arcs,
+// alternating above and below the line position.
+func wave(pd *pdfdraw.Object, wd, pos, lw bag.ScaledPoint) *pdfdraw.Object {
+	period := lw * 6
+	if period <= 0 {
+		return pd.Moveto(0, pos).Lineto(wd, pos)
+	}
+	amp := lw * 2
+	pd = pd.Moveto(0, pos)
+	up := true
+	for x := bag.ScaledPoint(0); x < wd; x += period {
+		next := x + period
+		if next > wd {
+			next = wd
+		}
+		y := pos + amp
+		if !up {
+			y = pos - amp
+		}
+		// One half period: rise to the crest and return to the line.
+		pd = pd.Curveto(x+(next-x)/3, y, x+2*(next-x)/3, y, next, pos)
+		up = !up
+	}
+	return pd
+}
+
 func postLinebreakHL(n node.Node, st *styles) node.Node {
-	underlineFromStart := st.isUnderline
-	var underlineStart, underlineStop node.Node
+	decoratedFromStart := st.decoration != TextDecorationLineNone
+	var decorationStart, decorationStop node.Node
 	var head, tail node.Node
 	head = n
 	for e := n; e != nil; e = e.Next() {
@@ -34,43 +122,55 @@ func postLinebreakHL(n node.Node, st *styles) node.Node {
 		} else if vl, ok := e.(*node.VList); ok {
 			vl.List = postLinebreakHL(vl.List, st)
 		} else if ss, ok := e.(*node.StartStop); ok {
-			if val, ok := ss.GetAttribute("underline"); ok {
-				if val.(bool) {
-					st.isUnderline = true
-					underlineStart = ss
-					if ulpos, ok := ss.GetAttribute("underlinepos"); ok {
-						if ulpos != nil {
-							st.ulpos = ulpos.(bag.ScaledPoint)
+			if val, ok := ss.GetAttribute("decoration"); ok {
+				if line, _ := val.(TextDecorationLine); line != TextDecorationLineNone {
+					st.decoration = line
+					decorationStart = ss
+					if pos, ok := ss.GetAttribute("decorationpos"); ok {
+						if pos != nil {
+							st.pos = pos.(bag.ScaledPoint)
 						}
 					}
-					if lw, ok := ss.GetAttribute("underlinelw"); ok {
+					if lw, ok := ss.GetAttribute("decorationlw"); ok {
 						if lw != nil {
 							st.linewidth = lw.(bag.ScaledPoint)
 						}
 					}
-				} else {
-					if underlineFromStart {
-						head = doUnderline(head, head, e, st)
+					st.style = TextDecorationStyleSolid
+					if v, ok := ss.GetAttribute("decorationstyle"); ok {
+						if style, ok := v.(TextDecorationStyle); ok {
+							st.style = style
+						}
 					}
-					st.isUnderline = false
-					underlineStop = ss
+					st.col = nil
+					if v, ok := ss.GetAttribute("decorationcolor"); ok {
+						if col, ok := v.(*color.Color); ok {
+							st.col = col
+						}
+					}
+				} else {
+					if decoratedFromStart {
+						head = drawDecoration(head, head, e, st)
+					}
+					st.decoration = TextDecorationLineNone
+					decorationStop = ss
 				}
 			}
 		}
-		if underlineStart != nil && underlineStop != nil {
-			head = doUnderline(head, underlineStart, underlineStop, st)
-			underlineStart = nil
-			underlineStop = nil
+		if decorationStart != nil && decorationStop != nil {
+			head = drawDecoration(head, decorationStart, decorationStop, st)
+			decorationStart = nil
+			decorationStop = nil
 		}
 	}
-	if st.isUnderline {
-		if underlineStart == nil && underlineStop == nil {
+	if st.decoration != TextDecorationLineNone {
+		if decorationStart == nil && decorationStop == nil {
 			// whole line
-			head = doUnderline(head, head, tail, st)
+			head = drawDecoration(head, head, tail, st)
 		}
-		if underlineStart != nil {
+		if decorationStart != nil {
 			// up to the end
-			head = doUnderline(head, underlineStart, tail, st)
+			head = drawDecoration(head, decorationStart, tail, st)
 		}
 	}
 	return head

--- a/frontend/nodebuilding.go
+++ b/frontend/nodebuilding.go
@@ -115,6 +115,55 @@ const (
 	TextDecorationLineThrough
 )
 
+// TextDecorationStyle is the CSS text-decoration-style property: how the
+// decoration line is drawn.
+type TextDecorationStyle int
+
+const (
+	// TextDecorationStyleSolid is a single unbroken line, the CSS default.
+	TextDecorationStyleSolid TextDecorationStyle = iota
+	// TextDecorationStyleDouble is two parallel lines.
+	TextDecorationStyleDouble
+	// TextDecorationStyleDotted is a dotted line.
+	TextDecorationStyleDotted
+	// TextDecorationStyleDashed is a dashed line.
+	TextDecorationStyleDashed
+	// TextDecorationStyleWavy is a wavy line.
+	TextDecorationStyleWavy
+)
+
+// WhiteSpace is the CSS white-space property (CSS Text 3 §3). It controls two
+// independent things at this level: whether a space keeps its exact glyph
+// advance, and whether a line may break at one. Whether runs of whitespace
+// collapse at all is decided earlier, when the text is extracted from the
+// markup.
+type WhiteSpace int
+
+const (
+	// WhiteSpaceNormal collapses whitespace and breaks lines at spaces.
+	WhiteSpaceNormal WhiteSpace = iota
+	// WhiteSpaceNowrap collapses whitespace but never breaks at a space.
+	WhiteSpaceNowrap
+	// WhiteSpacePre keeps every space at its own width and never breaks at one.
+	WhiteSpacePre
+	// WhiteSpacePreWrap keeps every space at its own width but may break at one.
+	WhiteSpacePreWrap
+	// WhiteSpacePreLine collapses spaces but keeps newlines as forced breaks.
+	WhiteSpacePreLine
+)
+
+// keepsSpaceWidth reports whether a space renders at its own glyph advance
+// rather than the font's inter-word default.
+func (ws WhiteSpace) keepsSpaceWidth() bool {
+	return ws == WhiteSpacePre || ws == WhiteSpacePreWrap
+}
+
+// breaksAtSpace reports whether a line may break at a space. `pre` and
+// `nowrap` do not wrap at all, which also means no hyphenation break.
+func (ws WhiteSpace) breaksAtSpace() bool {
+	return ws != WhiteSpacePre && ws != WhiteSpaceNowrap
+}
+
 // BorderStyle represents the HTML border styles such as solid, dashed, ...
 type BorderStyle uint
 
@@ -298,6 +347,16 @@ const (
 	// SettingItalicCorrection enables the heuristic kern between directly
 	// adjacent glyph runs of a slanted and an upright font (bool).
 	SettingItalicCorrection
+	// SettingWhiteSpace is the CSS white-space property (a WhiteSpace value).
+	// It decides two things about a space: whether it keeps its exact glyph
+	// advance, and whether a line may break there.
+	SettingWhiteSpace
+	// SettingTextDecorationStyle is how a decoration line is drawn (a
+	// TextDecorationStyle value).
+	SettingTextDecorationStyle
+	// SettingTextDecorationColor is the decoration line's colour. Unset means
+	// CSS's `currentColor`: the line takes the text colour.
+	SettingTextDecorationColor
 )
 
 // Direction describes the writing direction of a paragraph.
@@ -428,6 +487,12 @@ func (st SettingType) String() string {
 		settingName = "SettingPrepend"
 	case SettingPreserveWhitespace:
 		settingName = "SettingPreserveWhitespace"
+	case SettingWhiteSpace:
+		settingName = "SettingWhiteSpace"
+	case SettingTextDecorationStyle:
+		settingName = "SettingTextDecorationStyle"
+	case SettingTextDecorationColor:
+		settingName = "SettingTextDecorationColor"
 	case SettingRowspan:
 		settingName = "SettingRowspan"
 	case SettingSize:
@@ -576,6 +641,10 @@ func debugText(ts *Text, enc *xml.Encoder) {
 			v = node.StringValue(v.(node.Node))
 		case SettingPreserveWhitespace:
 			if v == false {
+				showSetting = false
+			}
+		case SettingWhiteSpace:
+			if v == WhiteSpaceNormal {
 				showSetting = false
 			}
 		case SettingTabSizeSpaces:
@@ -1686,12 +1755,16 @@ func (fe *Document) BuildNodelistFromString(ts TypesettingSettings, str string) 
 	var col *color.Color
 	var hyperlink document.Hyperlink
 	var hasHyperlink bool
-	var hasUnderline bool
+	// The text-decoration line to draw, or TextDecorationLineNone, and how.
+	decorationLine := TextDecorationLineNone
+	decorationStyle := TextDecorationStyleSolid
+	var decorationColor *color.Color
 	fontfeatures := make([]ot.Feature, 0, len(fe.DefaultFeatures))
 	for _, f := range fe.DefaultFeatures {
 		fontfeatures = append(fontfeatures, f)
 	}
 	preserveWhitespace := false
+	whiteSpace := WhiteSpaceNormal
 	letterSpacing := bag.ScaledPoint(0)
 	yoffset := bag.ScaledPoint(0)
 	direction := DirectionLTR
@@ -1739,8 +1812,18 @@ func (fe *Document) BuildNodelistFromString(ts TypesettingSettings, str string) 
 		case SettingDest:
 			// handled after node list is built
 		case SettingTextDecorationLine:
-			if underlineType, ok := v.(TextDecorationLine); ok && underlineType == TextDecorationUnderline {
-				hasUnderline = true
+			// Underline, overline and line-through differ only in where the
+			// rule sits; DecorationOffset knows the offsets.
+			if line, ok := v.(TextDecorationLine); ok {
+				decorationLine = line
+			}
+		case SettingTextDecorationStyle:
+			if st, ok := v.(TextDecorationStyle); ok {
+				decorationStyle = st
+			}
+		case SettingTextDecorationColor:
+			if col, ok := v.(*color.Color); ok {
+				decorationColor = col
 			}
 		case SettingFontExpansion:
 			// ignore
@@ -1770,6 +1853,10 @@ func (fe *Document) BuildNodelistFromString(ts TypesettingSettings, str string) 
 			// ignore
 		case SettingPreserveWhitespace:
 			preserveWhitespace = v.(bool)
+		case SettingWhiteSpace:
+			if ws, ok := v.(WhiteSpace); ok {
+				whiteSpace = ws
+			}
 		case SettingYOffset:
 			yoffset = v.(bag.ScaledPoint)
 		case SettingDirection:
@@ -1835,19 +1922,23 @@ func (fe *Document) BuildNodelistFromString(ts TypesettingSettings, str string) 
 			head = hyperlinkStart
 		}
 	}
-	var underlineStart *node.StartStop
-	if hasUnderline {
-		underlineStart = node.NewStartStop()
-		underlineStart.SetAttribute("underline", true)
-		underlineStart.SetAttribute("underlinepos", -fontsize/6)
-		underlineStart.SetAttribute("underlinelw", fontsize/20)
-		underlineStart.SetAttribute("SettingTextDecorationLine", TextDecorationUnderline)
-		if head != nil {
-			head = node.InsertAfter(head, head, underlineStart)
-		} else {
-			head = underlineStart
+	var decorationStart *node.StartStop
+	if decorationLine != TextDecorationLineNone {
+		decorationStart = node.NewStartStop()
+		decorationStart.SetAttribute("decoration", decorationLine)
+		decorationStart.SetAttribute("decorationpos", DecorationOffset(decorationLine, fontsize))
+		decorationStart.SetAttribute("decorationlw", fontsize/20)
+		decorationStart.SetAttribute("decorationstyle", decorationStyle)
+		if decorationColor != nil {
+			decorationStart.SetAttribute("decorationcolor", decorationColor)
 		}
-		underlineStart.Action = node.ActionUserSetting
+		decorationStart.SetAttribute("SettingTextDecorationLine", decorationLine)
+		if head != nil {
+			head = node.InsertAfter(head, head, decorationStart)
+		} else {
+			head = decorationStart
+		}
+		decorationStart.Action = node.ActionUserSetting
 	}
 	if col != nil {
 		colStart := node.NewStartStop()
@@ -1860,6 +1951,23 @@ func (fe *Document) BuildNodelistFromString(ts TypesettingSettings, str string) 
 		}
 		head = colStart
 	}
+	// Reconcile the white-space mode with the older SettingPreserveWhitespace
+	// boolean. The boolean is still set directly — the leader-pattern builder
+	// uses it to keep a thin space thin — and means the same as `pre`. Done
+	// here rather than in the settings loop because a map has no order.
+	switch {
+	case whiteSpace.keepsSpaceWidth():
+		preserveWhitespace = true
+	case preserveWhitespace:
+		whiteSpace = WhiteSpacePre
+	}
+	// `pre` and `nowrap` do not wrap, so a soft hyphen must not offer a break
+	// either. Pattern hyphenation is suppressed a layer up, where the run's
+	// hyphenator is chosen.
+	if !whiteSpace.breaksAtSpace() {
+		hyphensMode = "none"
+	}
+
 	cur = head
 	var lastglue node.Node
 	// When a CSS prioritised font-family list resolves to two or more
@@ -1878,11 +1986,21 @@ func (fe *Document) BuildNodelistFromString(ts TypesettingSettings, str string) 
 			if preserveWhitespace {
 				switch r.Components {
 				case " ", "\u00A0":
-					g := node.NewRule()
 					// Real glyph advance, not fnt.Space (TeX inter-word
 					// glue default of size*333/1000), so monospace ASCII
 					// art and code blocks line up column-for-column.
-					g.Width = fnt.SpaceChar.Advance
+					var g node.Node
+					if whiteSpace.breaksAtSpace() {
+						// pre-wrap: the width is fixed but the position is
+						// still a legal breakpoint, which a Rule is not.
+						gl := node.NewGlue()
+						gl.Width = fnt.SpaceChar.Advance
+						g = gl
+					} else {
+						r := node.NewRule()
+						r.Width = fnt.SpaceChar.Advance
+						g = r
+					}
 					head = node.InsertAfter(head, cur, g)
 					cur = g
 					lastglue = g
@@ -1962,8 +2080,10 @@ func (fe *Document) BuildNodelistFromString(ts TypesettingSettings, str string) 
 						// consumes adjacent whitespace — do not insert
 						// the default-space glue.
 					default:
-						if r.NoBreak {
-							// NBSP: insert Penalty(10000) to prevent line break
+						if r.NoBreak || !whiteSpace.breaksAtSpace() {
+							// NBSP, or white-space: nowrap — the space keeps its
+							// normal elastic width but must not offer a break, so
+							// it gets the same infinite penalty in front of it.
 							p := node.NewPenalty()
 							p.Penalty = 10000
 							head = node.InsertAfter(head, cur, p)
@@ -2064,12 +2184,12 @@ func (fe *Document) BuildNodelistFromString(ts TypesettingSettings, str string) 
 		node.InsertAfter(head, cur, stop)
 		cur = stop
 	}
-	if hasUnderline {
-		underlineStop := node.NewStartStop()
-		underlineStop.StartNode = underlineStart
-		underlineStop.SetAttribute("underline", false)
-		head = node.InsertAfter(head, cur, underlineStop)
-		cur = underlineStop
+	if decorationLine != TextDecorationLineNone {
+		decorationStop := node.NewStartStop()
+		decorationStop.StartNode = decorationStart
+		decorationStop.SetAttribute("decoration", TextDecorationLineNone)
+		head = node.InsertAfter(head, cur, decorationStop)
+		cur = decorationStop
 	}
 	if hasHyperlink {
 		hyperlinkStop = node.NewStartStop()

--- a/frontend/whitespace_test.go
+++ b/frontend/whitespace_test.go
@@ -1,0 +1,71 @@
+package frontend
+
+import (
+	"testing"
+
+	"github.com/boxesandglue/boxesandglue/backend/bag"
+)
+
+// TestWhiteSpaceAxes guards the two decisions the property makes at this
+// level. Whether whitespace collapses is settled earlier, when text is
+// extracted from the markup; what is left here is the space's width and
+// whether a line may break at it.
+//
+//   - keepsSpaceWidth: pre and pre-wrap render a space at its own glyph
+//     advance. The rest use the font's inter-word default.
+//   - breaksAtSpace: pre and nowrap do not wrap, which also means a soft
+//     hyphen must not offer a break.
+func TestWhiteSpaceAxes(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        WhiteSpace
+		keepWidth bool
+		breaks    bool
+	}{
+		{"normal", WhiteSpaceNormal, false, true},
+		{"nowrap", WhiteSpaceNowrap, false, false},
+		{"pre", WhiteSpacePre, true, false},
+		{"pre-wrap", WhiteSpacePreWrap, true, true},
+		{"pre-line", WhiteSpacePreLine, false, true},
+	}
+	for _, tc := range cases {
+		if got := tc.in.keepsSpaceWidth(); got != tc.keepWidth {
+			t.Errorf("%s: keepsSpaceWidth() = %v, want %v", tc.name, got, tc.keepWidth)
+		}
+		if got := tc.in.breaksAtSpace(); got != tc.breaks {
+			t.Errorf("%s: breaksAtSpace() = %v, want %v", tc.name, got, tc.breaks)
+		}
+	}
+}
+
+// TestWhiteSpaceZeroValue pins the Go zero value to CSS's initial value, so a
+// caller that never sets SettingWhiteSpace gets normal behaviour.
+func TestWhiteSpaceZeroValue(t *testing.T) {
+	var ws WhiteSpace
+	if ws != WhiteSpaceNormal {
+		t.Errorf("zero value = %v, want WhiteSpaceNormal", ws)
+	}
+}
+
+// TestDecorationOffset checks each line sits where its name says: the
+// underline below the baseline, the strike through the lowercase band, the
+// overline clear of the ascender.
+func TestDecorationOffset(t *testing.T) {
+	const size = bag.ScaledPoint(10 * 65536)
+	under := DecorationOffset(TextDecorationUnderline, size)
+	strike := DecorationOffset(TextDecorationLineThrough, size)
+	over := DecorationOffset(TextDecorationOverline, size)
+
+	if under >= 0 {
+		t.Errorf("underline offset = %v, want below the baseline", under)
+	}
+	if strike <= 0 || strike >= over {
+		t.Errorf("line-through offset = %v, want between the baseline and the overline (%v)", strike, over)
+	}
+	if over <= 0 || over >= size {
+		t.Errorf("overline offset = %v, want above the baseline and within the em", over)
+	}
+	if got := DecorationOffset(TextDecorationLineNone, size); got != 0 {
+		t.Errorf("none offset = %v, want 0", got)
+	}
+}


### PR DESCRIPTION
Two CSS properties that were declared in full and implemented in part.

## Gap 1: white-space

Only `SettingPreserveWhitespace` existed, a boolean meaning "keep exact widths, never break at a space". That is `pre`. The other four CSS values had no representation:

- `pre-line` (collapse spaces, keep newlines) could not be expressed at all, which is the value wanted for prose carrying a hard break.
- `pre-wrap` (keep spaces and newlines, still wrap) could not be expressed.
- `nowrap` (collapse, never break) could not be expressed.

Separately, `pre` broke lines at soft hyphens. CSS Text 3 §3 says the value suppresses line breaking within the text, so the line should overflow instead.

## Gap 2: text-decoration

`TextDecorationLine` has always declared `TextDecorationOverline` and `TextDecorationLineThrough`, but `BuildNodelistFromString` tested only for `TextDecorationUnderline`, so the other two were accepted and silently discarded. `text-decoration-style` and `text-decoration-color` had no setting.

## Fix

`WhiteSpace` type plus `SettingWhiteSpace`. At this level the property decides two independent things, which is what the two unexported predicates name:

| value | space width | breaks at space |
|---|---|---|
| `normal` | font inter-word | yes |
| `nowrap` | font inter-word | no |
| `pre` | glyph advance | no |
| `pre-wrap` | glyph advance | yes |
| `pre-line` | font inter-word | yes |

`pre-wrap` is the same fixed width as `pre` emitted as a glue rather than a rule: a glue after a box is a legal breakpoint and a rule is not, so that one node choice is the whole difference. `nowrap` reuses the `Penalty(10000)` that NBSP already inserts. `pre` and `nowrap` set `hyphensMode` to `none`, which stops the soft-hyphen `Disc`.

For decorations, all three lines differ only in offset from the baseline, so `doUnderline` becomes `drawDecoration` and `DecorationOffset` names the three offsets. They are fractions of the font size, as the underline offset already was; no font source here exposes post/OS-2 underline or strikeout metrics. `text-decoration-style` draws through `pdfdraw`: `double` is two lines, `dotted` and `dashed` are `SetDash`, `wavy` is a run of half-period Beziers.

## Repercussions

- `SettingPreserveWhitespace` is unchanged in meaning and behaviour, and still produces rules for spaces and no breaks. It is reconciled with the new setting after the settings map is read, not inside the loop, because a map has no iteration order. The leader-pattern builder in this package sets it directly and is unaffected.
- `WhiteSpace`'s zero value is `WhiteSpaceNormal`, so a caller that never sets `SettingWhiteSpace` gets today's behaviour.
- `pre` no longer breaks at a soft hyphen. A `pre` line that previously hyphenated will now overflow its box, which is the spec behaviour but is a visible change for existing input.
- The `StartStop` marker attributes are renamed `underline`, `underlinepos`, `underlinelw` to `decoration`, `decorationpos`, `decorationlw`, and `decoration` now carries a `TextDecorationLine` rather than a `bool`. They are read only by `decoration.go` and written only by `nodebuilding.go`, both in this package. `grep -rn '"underline"'` finds no other reader.
- `SettingTextDecorationStyle` and `SettingTextDecorationColor` are appended to the `Setting` enum, so no existing constant changes value.
- Overline and line-through now draw where they previously did nothing. Callers passing those values were getting no line.
- `pdfdraw.SetDash` takes `[]uint` of PDF units, so a dotted pattern cannot be finer than one unit. Under a 0.5pt rule the pattern is 1pt on/off rather than scaled to the rule.
- Several lines at once (`text-decoration-line: underline overline`) is still not representable: the enum is a plain iota, so a set would mean changing the exported constants to a bitmask or letting the setting take a slice. Not attempted here.

## Related

- boxesandglue/htmlbag maps the CSS side of both properties onto these settings. That change depends on this one.
- boxesandglue/csshtml#2 is needed for `text-decoration-style` to arrive at all: the resolver currently overwrites it with `solid` whenever a line is set.

Tested with `go test ./...` on this branch. `frontend/whitespace_test.go` covers the two white-space axes, the zero value, and the three decoration offsets.
