### PR TITLE
Fix two table cell measurement bugs

### DIFF
--- a/frontend/nodehelper.go
+++ b/frontend/nodehelper.go
@@ -28,19 +28,29 @@ func maxWidthWithoutStretch(vl *node.VList) bag.ScaledPoint {
 }
 
 func getMaxWidthHlistWithoutStretch(hl *node.HList) bag.ScaledPoint {
-	var start, stop node.Node
-	start = hl.List
-	stop = node.Tail(hl.List)
+	return naturalWidthWithoutStretch(hl)
+}
+
+// naturalWidthWithoutStretch sums a line's horizontal extent, ignoring glue that
+// carries infinite stretch. That glue is alignment filler: rightskip for ragged
+// right, leftskip for text-align:right, and both for center.
+//
+// This scan used to stop at the first such glue, which is only correct when the
+// filler trails the content. With text-align:right or :center the filler comes
+// first, so the scan measured nothing and the line reported a natural width of
+// zero — and a table cell containing a centred or right-aligned paragraph
+// collapsed the whole table to min-content.
+func naturalWidthWithoutStretch(hl *node.HList) bag.ScaledPoint {
+	var wd bag.ScaledPoint
 	for e := hl.List; e != nil; e = e.Next() {
-		stop = e
 		if e.Type() == node.TypeGlue {
 			if gl := e.(*node.Glue); gl.StretchOrder > 0 {
-				break
+				continue
 			}
 		}
+		w, _, _ := node.Dimensions(e, e, node.Horizontal)
+		wd += w
 	}
-
-	wd, _, _ := node.Dimensions(start, stop, node.Horizontal)
 	return wd
 }
 
@@ -62,18 +72,5 @@ func minWidthWithoutStretch(vl *node.VList) bag.ScaledPoint {
 }
 
 func getMinWidthHlistWithoutStretch(hl *node.HList) bag.ScaledPoint {
-	var start, stop node.Node
-	start = hl.List
-	stop = node.Tail(hl.List)
-	for e := hl.List; e != nil; e = e.Next() {
-		stop = e
-		if e.Type() == node.TypeGlue {
-			if gl := e.(*node.Glue); gl.StretchOrder > 0 {
-				break
-			}
-		}
-	}
-
-	wd, _, _ := node.Dimensions(start, stop, node.Horizontal)
-	return wd
+	return naturalWidthWithoutStretch(hl)
 }

--- a/frontend/nodehelper_test.go
+++ b/frontend/nodehelper_test.go
@@ -1,0 +1,78 @@
+package frontend
+
+import (
+	"testing"
+
+	"github.com/boxesandglue/boxesandglue/backend/bag"
+	"github.com/boxesandglue/boxesandglue/backend/node"
+)
+
+// filGlue is the alignment filler a line carries: rightskip for ragged right,
+// leftskip for text-align:right, one of each for center. Its defining property
+// is infinite stretch, which is what marks it as not-content.
+func filGlue() *node.Glue {
+	g := node.NewGlue()
+	g.Stretch = bag.MustSP("1pt")
+	g.StretchOrder = node.StretchFil
+	return g
+}
+
+func fixedGlue(wd bag.ScaledPoint) *node.Glue {
+	g := node.NewGlue()
+	g.Width = wd
+	return g
+}
+
+func ruleOfWidth(wd bag.ScaledPoint) *node.Rule {
+	r := node.NewRule()
+	r.Width = wd
+	r.Height = bag.MustSP("10pt")
+	return r
+}
+
+func line(items ...node.Node) *node.HList {
+	var head node.Node
+	for _, item := range items {
+		head = node.InsertAfter(head, node.Tail(head), item)
+	}
+	return node.Hpack(head)
+}
+
+// TestNaturalWidthIgnoresAlignmentFiller checks that a line's natural width is
+// the width of its content wherever the alignment filler happens to sit. The
+// scan used to stop at the first infinitely stretchable glue, which is only
+// the right thing to do when that glue trails the content. Lead with it, as
+// text-align:right and :center do, and the line measured zero.
+func TestNaturalWidthIgnoresAlignmentFiller(t *testing.T) {
+	want := bag.MustSP("50pt")
+
+	cases := []struct {
+		name string
+		hl   *node.HList
+	}{
+		{"ragged right", line(ruleOfWidth(want), filGlue())},
+		{"text-align:right", line(filGlue(), ruleOfWidth(want))},
+		{"text-align:center", line(filGlue(), ruleOfWidth(want), filGlue())},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := getMaxWidthHlistWithoutStretch(tc.hl); got != want {
+				t.Errorf("max width = %s, want %s", got, want)
+			}
+			if got := getMinWidthHlistWithoutStretch(tc.hl); got != want {
+				t.Errorf("min width = %s, want %s", got, want)
+			}
+		})
+	}
+}
+
+// TestNaturalWidthKeepsFiniteGlue guards the other half of the rule: only
+// infinite stretch is filler. An ordinary interword space is content and is
+// measured at its natural width.
+func TestNaturalWidthKeepsFiniteGlue(t *testing.T) {
+	hl := line(ruleOfWidth(bag.MustSP("30pt")), fixedGlue(bag.MustSP("5pt")), ruleOfWidth(bag.MustSP("20pt")))
+	want := bag.MustSP("55pt")
+	if got := getMaxWidthHlistWithoutStretch(hl); got != want {
+		t.Errorf("max width = %s, want %s", got, want)
+	}
+}

--- a/frontend/table.go
+++ b/frontend/table.go
@@ -217,6 +217,20 @@ func (cell *TableCell) maxWidth() (bag.ScaledPoint, error) {
 	return maxwd + cell.BorderLeftWidth + cell.BorderRightWidth + cell.PaddingLeft + cell.PaddingRight, nil
 }
 
+// allVLists reports whether every item in the list is block-level, and so has to
+// be stacked rather than packed horizontally.
+func allVLists(head node.Node) bool {
+	if head == nil {
+		return false
+	}
+	for n := head; n != nil; n = n.Next() {
+		if _, ok := n.(*node.VList); !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func (cell *TableCell) build() (*node.VList, error) {
 	fe := cell.row.table.doc
 	paraWidth := cell.CalculatedWidth - cell.calculatedBorderLeftWidth - cell.calculatedBorderRightWidth - cell.PaddingLeft - cell.PaddingRight
@@ -268,6 +282,14 @@ func (cell *TableCell) build() (*node.VList, error) {
 	// If head is already a single VList, use it directly; otherwise pack horizontally first
 	if existingVL, ok := head.(*node.VList); ok && head.Next() == nil {
 		vl = existingVL
+	} else if allVLists(head) {
+		// Several block-level items — one paragraph per line of a multi-line
+		// value, say — have to STACK. HpackTo lays them out side by side, which
+		// leaves the cell one line tall and pushes everything after the first
+		// past the cell's width, where the next row overdraws it: the content
+		// disappears with no warning and no overflow diagnostic.
+		vl = node.Vpack(head)
+		vl.Attributes = node.H{"origin": "vpack cell"}
 	} else {
 		hl := node.HpackTo(head, paraWidth)
 		hl.Attributes = node.H{"origin": "hpack cell"}

--- a/frontend/table_test.go
+++ b/frontend/table_test.go
@@ -59,3 +59,35 @@ func TestRowspanHeightDistribution(t *testing.T) {
 			tbl.rowHeights[0], tbl.rowHeights[1])
 	}
 }
+
+// TestCellStacksBlockContents checks that a cell holding more than one
+// block-level item stacks them. They used to be HpackTo'd, which laid them out
+// side by side: the cell stayed one item tall and everything after the first
+// was pushed past the cell's width, where the next row drew over it. The
+// content vanished with no warning and no overflow diagnostic.
+func TestCellStacksBlockContents(t *testing.T) {
+	fe, err := NewForWriter(io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const blockHeight = "30pt"
+	cell := &TableCell{Contents: []any{
+		fixedBox(bag.MustSP("20pt"), bag.MustSP(blockHeight)),
+		fixedBox(bag.MustSP("20pt"), bag.MustSP(blockHeight)),
+	}}
+
+	tbl := &Table{
+		MaxWidth: bag.MustSP("200pt"),
+		Rows:     TableRows{&TableRow{Cells: []*TableCell{cell}}},
+	}
+	if _, err = fe.BuildTable(tbl); err != nil {
+		t.Fatal(err)
+	}
+
+	want := 2 * bag.MustSP(blockHeight)
+	if tbl.rowHeights[0] < want {
+		t.Errorf("row height = %s, want at least %s: the second block was not stacked",
+			tbl.rowHeights[0], want)
+	}
+}


### PR DESCRIPTION
Two independent bugs, one commit each. Both surface as a table cell that measures wrong.

## Gap 1: a line's natural width is zero when the alignment filler leads

`getMaxWidthHlistWithoutStretch` walks the line to find the last node before the first glue with `StretchOrder > 0`, then measures `start..stop`.

That glue is alignment filler, and the assumption that it trails the content holds only for ragged right, where the filler is rightskip. `text-align: right` leads with leftskip; `center` has one at each end. In both cases the first node examined is the filler, the scan breaks immediately, and `node.Dimensions(hl.List, hl.List, ...)` measures the glue alone: natural width 0.

The callers are `maxWidthWithoutStretch` and `minWidthWithoutStretch`, which feed table column sizing. A table with a centred or right-aligned paragraph in any cell reports a content width of zero for that column and collapses to min-content.

## Gap 2: multiple block-level items in a cell are packed side by side

`TableCell.build()` fast-paths a single `*node.VList` and otherwise calls `node.HpackTo`. Contents of more than one block, two paragraphs or several `FormatToVList` boxes, are block-level and have to stack. Hpacked, the cell stays as tall as its tallest single item and everything after the first is placed past the cell's width, where the following row draws over it. Nothing reports an overflow; the content is silently gone.

## Fix

1. Both width scans become one helper that sums the line and skips infinitely stretchable glue rather than stopping at it. `getMinWidthHlistWithoutStretch` was byte-identical to the max version, so it now shares the implementation.
2. `build()` gains a third case: when every item in the list is a `*node.VList`, `node.Vpack` them.

## Repercussions

- Ragged-right lines measure the same as before. Skipping trailing filler and stopping at it give the same sum.
- A line whose content sits after the filler previously measured 0 and now measures its content. That is the fix, but it changes column widths in existing tables containing right-aligned or centred cells.
- Only `StretchOrder > 0` is skipped, so an ordinary interword space was counted before and still is.
- The vpack path triggers only where the old code produced an hpack of several vlists, which had no correct rendering. A cell that already hit the single-VList fast path is untouched. Mixed lists still hpack, so an inline `*node.HList` beside text is unaffected.
- Worth noting separately: min and max content width are the same computation here, and were before this change. This does not address that.

`frontend/nodehelper_test.go` and the new case in `frontend/table_test.go` both fail on main. `go test ./...` passes on the branch.
