### PR TITLE
Take the interword space from the font rather than from cmr10

### DIFF
--- a/backend/font/font.go
+++ b/backend/font/font.go
@@ -76,7 +76,11 @@ func NewFont(face *pdf.Face, size bag.ScaledPoint) *Font {
 		// at 0.278em and Crimson Pro at 0.1875em, against the 0.333em
 		// assumed here. Stretch and shrink keep the 1 : 1/2 : 1/3 ratios
 		// those same defaults encode.
-		if adv := spacechar[0].Advance; adv > 0 {
+		//
+		// A font without a space glyph shapes U+0020 to .notdef, whose
+		// advance is arbitrary (Twemoji: 1em, a NotoColorEmoji subset:
+		// 1.24em), so require a real glyph and keep the defaults otherwise.
+		if adv := spacechar[0].Advance; adv > 0 && spacechar[0].Codepoint != 0 {
 			fnt.Space = adv
 			fnt.SpaceStretch = adv / 2
 			fnt.SpaceShrink = adv / 3

--- a/backend/font/font.go
+++ b/backend/font/font.go
@@ -70,6 +70,17 @@ func NewFont(face *pdf.Face, size bag.ScaledPoint) *Font {
 	spacechar := fnt.Shape(" ", nil, nil)
 	if len(spacechar) == 1 {
 		fnt.SpaceChar = spacechar[0]
+		// Interword glue is the font's own space advance. The defaults set
+		// above are cmr10's fontdimen2/3/4, which are right for that font
+		// and wrong for every other one: TeX Gyre Heros designs its space
+		// at 0.278em and Crimson Pro at 0.1875em, against the 0.333em
+		// assumed here. Stretch and shrink keep the 1 : 1/2 : 1/3 ratios
+		// those same defaults encode.
+		if adv := spacechar[0].Advance; adv > 0 {
+			fnt.Space = adv
+			fnt.SpaceStretch = adv / 2
+			fnt.SpaceShrink = adv / 3
+		}
 	}
 	return fnt
 }

--- a/backend/font/font_test.go
+++ b/backend/font/font_test.go
@@ -1,0 +1,45 @@
+package font_test
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/boxesandglue/boxesandglue/backend/bag"
+	"github.com/boxesandglue/boxesandglue/backend/document"
+	"github.com/boxesandglue/boxesandglue/backend/font"
+)
+
+// TestInterwordSpaceFromFont checks that a font's interword glue comes from its
+// own space glyph rather than from cmr10's fontdimen2. TeX Gyre Heros designs
+// its space at 278/1000 em; the hardcoded default was 333/1000, so a 10pt font
+// set every space 20% too wide.
+func TestInterwordSpaceFromFont(t *testing.T) {
+	const fontFile = "../../qa/fonts/upem/fonts/texgyreheros-regular.otf"
+	if _, err := os.Stat(fontFile); err != nil {
+		t.Skipf("font fixture missing: %v", err)
+	}
+
+	doc := document.NewDocument(io.Discard)
+	face, err := doc.LoadFace(fontFile, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	size := bag.MustSP("10pt")
+	fnt := font.NewFont(face, size)
+
+	want := size * 278 / 1000
+	if diff := fnt.Space - want; diff > bag.MustSP("0.01pt") || diff < -bag.MustSP("0.01pt") {
+		t.Errorf("Space = %s, want %s (the font's own space advance)", fnt.Space, want)
+	}
+	if fnt.Space != fnt.SpaceChar.Advance {
+		t.Errorf("Space = %s, SpaceChar.Advance = %s: they should agree", fnt.Space, fnt.SpaceChar.Advance)
+	}
+	if fnt.SpaceStretch != fnt.Space/2 {
+		t.Errorf("SpaceStretch = %s, want %s", fnt.SpaceStretch, fnt.Space/2)
+	}
+	if fnt.SpaceShrink != fnt.Space/3 {
+		t.Errorf("SpaceShrink = %s, want %s", fnt.SpaceShrink, fnt.Space/3)
+	}
+}


### PR DESCRIPTION
## Gap

`NewFont` sets the interword glue from three constants:

```go
Space:        size * 333 / 1000,
SpaceStretch: size * 167 / 1000,
SpaceShrink:  size * 111 / 1000,
```

Those are cmr10's `fontdimen2`, `fontdimen3` and `fontdimen4`. They are applied to every font. Twelve lines further down `NewFont` already shapes the space glyph and stores it in `SpaceChar`, so the font's own advance is in hand and unused.

Measured at 10pt against the fixtures in `qa/fonts/upem/fonts`:

| font | designed space | assumed | error |
|---|---|---|---|
| TeX Gyre Heros (Helvetica metrics) | 0.278 em | 0.333 em | +20% |
| Arugula LAB | 0.210 em | 0.333 em | +59% |
| Crimson Pro | 0.1875 em | 0.333 em | +78% |

The error is per space, so it accumulates along a line. Justified text absorbs it into the glue and comes out loose or tight; ragged text carries it into the line-break decision.

`frontend/nodebuilding.go` already distinguishes the two values: under `white-space: pre` and `pre-wrap` it deliberately uses `fnt.SpaceChar.Advance` because the space has to be exact there. That is the same number this change makes the default.

## Fix

When the space glyph shapes to a single atom, take `Space` from its advance and derive stretch and shrink from that. The 1 : 1/2 : 1/3 ratios are unchanged: 333, 167 and 111 are already `space`, `space/2` and `space/3`, so only the base moves. A font whose space does not shape keeps the old defaults.

## Repercussions

This one is not free, and it is worth being explicit about it.

- Every document set in a font whose space is not 0.333em gets different line breaks. Existing output will reflow. There is no font in these fixtures for which the value does not change.
- Spaces get narrower in every case measured, so lines fit more words and paragraphs tend to get shorter.
- `frontend/nodebuilding.go` also uses `fnt.Space` for indents (`nspaces * fnt.Space`) and for the leader fallback (`4 * fnt.Space`). Those scale with it.
- `pre` and `pre-wrap` are unaffected: they already used the glyph advance, and now agree with normal flow instead of differing from it.
- No API change. `SpaceStretch` and `SpaceShrink` remain settable by a caller after `NewFont` returns.

If you would rather not change the default, the same code behind a flag on `Font` or a package-level toggle is a small edit. Say which you prefer and I will redo it.

`backend/font/font_test.go` pins Heros at 0.278em; it fails on main with 3.33 against 2.78. The test skips if the fixture is missing, since it reaches into `qa/` for a font and the package has no fixture of its own.
