### PR TITLE
Stop a decoration at the text, not at the end of the line

### DIFF
--- a/frontend/decoration.go
+++ b/frontend/decoration.go
@@ -39,6 +39,26 @@ func DecorationOffset(line TextDecorationLine, fontsize bag.ScaledPoint) bag.Sca
 	return 0
 }
 
+// lastInked walks back from stop to the last node that puts ink on the line, so
+// a decoration still open at a line break stops at the text. The nodes at the
+// end of a broken line are the break's own glue and the alignment filler, and
+// including them drew the underline out to the margin: a wrapped underlined
+// heading was underlined across the gap after its last word.
+func lastInked(start, stop node.Node) node.Node {
+	for e := stop; e != nil; e = e.Prev() {
+		switch e.(type) {
+		case *node.Glue, *node.Penalty:
+			// Not ink; keep walking back, unless there is nothing before it.
+			if e == start {
+				return stop
+			}
+		default:
+			return e
+		}
+	}
+	return stop
+}
+
 func drawDecoration(head, start, stop node.Node, st *styles) node.Node {
 	wd, _, _ := node.Dimensions(start, stop, node.Horizontal)
 	pd := pdfdraw.NewStandalone().LineWidth(st.linewidth)
@@ -166,11 +186,11 @@ func postLinebreakHL(n node.Node, st *styles) node.Node {
 	if st.decoration != TextDecorationLineNone {
 		if decorationStart == nil && decorationStop == nil {
 			// whole line
-			head = drawDecoration(head, head, tail, st)
+			head = drawDecoration(head, head, lastInked(head, tail), st)
 		}
 		if decorationStart != nil {
 			// up to the end
-			head = drawDecoration(head, decorationStart, tail, st)
+			head = drawDecoration(head, decorationStart, lastInked(decorationStart, tail), st)
 		}
 	}
 	return head

--- a/frontend/decoration_trailing_test.go
+++ b/frontend/decoration_trailing_test.go
@@ -1,0 +1,67 @@
+package frontend
+
+import (
+	"testing"
+
+	"github.com/boxesandglue/boxesandglue/backend/bag"
+	"github.com/boxesandglue/boxesandglue/backend/node"
+)
+
+// TestLastInkedStopsAtText checks where a decoration left open at a line break
+// ends. The nodes at the end of a broken line are the break's own glue and the
+// alignment filler, and drawing through them ran the underline out to the
+// margin: a wrapped underlined heading came out underlined across the gap
+// after its last word.
+func TestLastInkedStopsAtText(t *testing.T) {
+	glyph := func() node.Node {
+		r := node.NewRule() // stands in for text: any node that is not glue
+		r.Width = bag.MustSP("10pt")
+		return r
+	}
+	glue := func() node.Node {
+		g := node.NewGlue()
+		g.Width = bag.MustSP("4pt")
+		return g
+	}
+
+	build := func(items ...node.Node) (node.Node, node.Node) {
+		var head, tail node.Node
+		for _, it := range items {
+			head = node.InsertAfter(head, tail, it)
+			tail = it
+		}
+		return head, tail
+	}
+
+	t.Run("trailing glue is trimmed", func(t *testing.T) {
+		want := glyph()
+		head, tail := build(glyph(), glue(), want, glue())
+		if got := lastInked(head, tail); got != want {
+			t.Errorf("stopped at %T, want the last non-glue node", got)
+		}
+	})
+
+	t.Run("a line ending in text is unchanged", func(t *testing.T) {
+		want := glyph()
+		head, tail := build(glyph(), glue(), want)
+		if got := lastInked(head, tail); got != want {
+			t.Errorf("stopped at %T, want the final node itself", got)
+		}
+	})
+
+	t.Run("interior glue is kept", func(t *testing.T) {
+		// The spaces between words stay underlined; only what trails does not.
+		want := glyph()
+		head, tail := build(glyph(), glue(), glue(), want)
+		if got := lastInked(head, tail); got != want {
+			t.Errorf("stopped at %T, want the last node", got)
+		}
+	})
+
+	t.Run("a line of nothing but glue falls back to the end", func(t *testing.T) {
+		head, tail := build(glue(), glue())
+		if got := lastInked(head, tail); got != tail {
+			t.Errorf("got %T, want the original stop rather than nothing", got)
+		}
+	})
+}


### PR DESCRIPTION
## Gap

`postLinebreakHL` closes an open decoration at the end of a line with

```go
head = drawDecoration(head, decorationStart, tail, st)
```

`tail` is the line's last node, and on a broken line that is the glue the break consumed plus the alignment filler. `drawDecoration` measures `start..stop` with `node.Dimensions`, so the rule is drawn across them and reaches the margin.

The last line of a paragraph is unaffected, since it has no filler to run through. So an underlined heading that wraps is underlined correctly on its final line and over-long on every line above it. Measured on a 200pt column with a two-line underlined heading: the glyphs end at 570px and the rule ended at 633px, the full line width.

This is a bug in #23, which is mine.

## Fix

Walk back from `tail` to the last node that is not glue or a penalty, and stop there. Interior glue keeps its decoration, which is what CSS Text Decoration 3 §1.3 wants: the spaces between words are underlined, the whitespace at a break is not.

A line that is nothing but glue falls back to the original `tail`, so the degenerate case cannot produce a backwards range.

## Repercussions

- Only the two end-of-line calls change. A decoration closed by its own `StartStop` marker mid-line already stopped at the marker, and is untouched.
- Any document with a decoration crossing a line break gets a shorter rule on every line but the last. That is the fix, and it is a visible change.
- Kerns are treated as ink and left alone: a trailing kern is a positioning adjustment on the preceding glyph rather than something appended after it.

`frontend/decoration_trailing_test.go` covers the trim, a line already ending in text, interior glue, and the glue-only line. `go test ./...` passes.
